### PR TITLE
fix: remove invisible `<span>` from Antora UI

### DIFF
--- a/antora-ui-camel/src/partials/header-content.hbs
+++ b/antora-ui-camel/src/partials/header-content.hbs
@@ -1,7 +1,7 @@
 <header class="header">
   <nav class="navbar">
     <div class="navbar-brand">
-      <a class="nav-logo" href="{{siteRootPath}}"><span>{{site.title}}</span></a>
+      <a class="nav-logo" href="{{siteRootPath}}"></a>
       <div id="topbar-nav" class="navbar-menu">
         <div class="navbar-end">
           {{#withMenuData}}


### PR DESCRIPTION
This makes the corresponding change made to Hugo templates in #199 in the Antora UI theme as well.